### PR TITLE
Update of PENBBScan2D

### DIFF
--- a/src/6pmt_util/PENBBScan2D.jl
+++ b/src/6pmt_util/PENBBScan2D.jl
@@ -100,6 +100,7 @@ function PENBBScan2D(settings, start, step, ends, HolderName, motor; notebook=fa
                 # For this, it throws and error to task t
                 if istaskdone(t) == false || ts < settings["measurement_time"] * settings["number_of_measurements"]
                     @async Base.throwto(t, EOFError())
+                    kill_all_java_processes(2 * settings["measurement_time"])
                     cd(cur_dir)
                     push!(missed_positions["x"], i)
                     push!(missed_positions["y"], j)

--- a/src/6pmt_util/PENBBScan2D.jl
+++ b/src/6pmt_util/PENBBScan2D.jl
@@ -29,7 +29,7 @@ function PENBBScan2D(settings, start, step, ends, HolderName, motor; notebook=fa
         for i in collect(start[1]:step[1]:ends[1])
             XMoveMM(i,motor)
             @showprogress "Performing y scan for x=$i " for j in collect(start[2]:step[2]:ends[2])
-                @info(string("Points skipped: ", length(missed_positions["x"])))
+                #@info(string("Points skipped: ", length(missed_positions["x"])))
                 @info("position: ",i,j)
                 YMoveMM(j,motor)
                 pos_x = PosX(motor)
@@ -78,51 +78,51 @@ function PENBBScan2D(settings, start, step, ends, HolderName, motor; notebook=fa
                     coincidence_interval = settings["coincidence_interval"]
                 );
                 println(name_file)
-                #
-                ## Create asynchronous task for data taking
-                t = @async try take_struck_data(settings_nt, calibration_data=settings["calibration_data"])
-                    catch e 
-                    println("stopped on $e") 
-                end
                 
-                # Create timeout check
-                ts = 1
-                prog = Progress(2*settings["measurement_time"] * settings["number_of_measurements"], "Time till skip:")
-                while istaskdone(t) == false && ts <= 2 * settings["measurement_time"] * settings["number_of_measurements"]
-                    # This loop will break when task t is compleded
-                    # or when the time is over
-                    sleep(1)
-                    ts += 1
-                    next!(prog)
-                end
+                # Measure until the data-taking succeeds
+                done::Bool = false 
+                while !done
                 
-                # After the loop has ended, this extra check will interrupt the data taking if needed
-                # For this, it throws and error to task t
-                if istaskdone(t) == false || ts < settings["measurement_time"] * settings["number_of_measurements"]
-                    @async Base.throwto(t, EOFError())
-                    kill_all_java_processes(2 * settings["measurement_time"])
-                    cd(cur_dir)
-                    push!(missed_positions["x"], i)
-                    push!(missed_positions["y"], j)
-                    open("missing_log_" * HolderName * ".json",  "w") do f
-                        JSON.print(f, missed_positions, 4)
+                    ## Create asynchronous task for data taking
+                    t = @async try take_struck_data(settings_nt, calibration_data=settings["calibration_data"])
+                        catch e 
+                        println("stopped on $e") 
                     end
-                else
+                    
+                    # Create timeout check
+                    ts = 1
+                    prog = Progress(2*settings["measurement_time"] * settings["number_of_measurements"], "Time till skip:")
+                    while istaskdone(t) == false && ts <= 2 * settings["measurement_time"] * settings["number_of_measurements"]
+                        # This loop will break when task t is compleded
+                        # or when the time is over
+                        sleep(1)
+                        ts += 1
+                        next!(prog)
+                    end
+                    
+                    # After the loop has ended, this extra check will interrupt the data taking if needed
+                    # For this, it throws and error to task t and kills all java processes (if scala process freezes)
+                    if istaskdone(t) == false || ts < settings["measurement_time"] * settings["number_of_measurements"]
+                        @async Base.throwto(t, EOFError())
+                        kill_all_java_processes(2 * settings["measurement_time"])
+                    else # Data taking was successful
+                        done = true 
+                    end
+                    
                     cd(cur_dir)
-                end
-                
-                sleep(2)
-                # Clear output to reduce memory taken by notebook
-                if notebook
-                    IJulia.clear_output(true)
-                else
-                    Base.run(`clear`)
-                end                
+                    sleep(2)
+                    
+                    # Clear output to reduce memory taken by notebook
+                    if notebook
+                        IJulia.clear_output(true)
+                    else
+                        Base.run(`clear`)
+                    end 
+                end              
             end
         end
         @info("PEN BB 2D scan completed, see you soon!")
     end
-
-    @info("Missed positions are listed here:")
+    #@info("Missed positions are listed here:")
     return missed_positions
 end

--- a/src/util/util.jl
+++ b/src/util/util.jl
@@ -35,9 +35,9 @@ function kill_all_java_processes(min_time_s::Real = 0)
         try run(pipeline(`ps -p $(pid) -o etime`, stdout = time)) catch ; end
         close(time.in)
         elapsed_time = replace(split(String(read(time))," ")[end], "\n" => "")
-        if Time(elapsed_time, "MM:SS") - Time("0") > Second(min_time_s)
+        if length(elapsed_time) > 5 || Time(elapsed_time, "MM:SS") - Time("0") > Second(min_time_s)
             run(`kill $(pid)`)
-            @info("  Process id $(pid) killed (running for $(elapsed_time) minutes)")
+            @info("  Process id $(pid) killed (running for $(elapsed_time)$(length(elapsed_time) == 5 ? " minutes" : ""))")
         end
     end
 end

--- a/src/util/util.jl
+++ b/src/util/util.jl
@@ -19,3 +19,25 @@ function entrysel(predicate, ds, colname)
 end
 
 export entrysel
+
+# This functions kills all java processes that have been running longer than a given time "min_time_s"
+function kill_all_java_processes(min_time_s::Real = 0)
+    @info "Kill all java processes" * (min_time_s == 0 ? "" : "running longer than $(min_time_s) seconds")
+    out = Pipe()
+    try
+        run(pipeline(`pgrep java`, stdout = out)) # results in an error if no java processes are running
+    catch
+        @info "No java processes running"
+    end
+    close(out.in)
+    for pid in filter!(x -> x != "", split(String(read(out)), "\n"))
+        time = Pipe()
+        try run(pipeline(`ps -p $(pid) -o etime`, stdout = time)) catch ; end
+        close(time.in)
+        elapsed_time = replace(split(String(read(time))," ")[end], "\n" => "")
+        if Time(elapsed_time, "MM:SS") - Time("0") > Second(min_time_s)
+            run(`kill $(pid)`)
+            @info("  Process id $(pid) killed (running for $(elapsed_time) minutes)")
+        end
+    end
+end


### PR DESCRIPTION
Some days ago, a longer measurement based on `PENBBScan2D()` was terminated because a number of java processes were not terminated which lead to a memory overflow.

![java_processes](https://user-images.githubusercontent.com/30291312/117452351-f4395600-af43-11eb-969a-5acf2d0f3db3.JPG)

This happens when the data-taking task freezes (happens sometimes if STRUCK data is taken with a `scala` script).
The code tries to avoid this with [throwing an `EOFError()`](https://github.com/mppmu/PENScintAnalysis.jl/blob/master/src/6pmt_util/PENBBScan2D.jl#L102). However, this does not end the java processes, such that they keep on filling the memory.

This pull request is **NOT TESTED** with the real setup, so please try it out with my fork before possibly merging. It includes:
- A function to kill **ALL** java processes that are older than a given time in seconds 
- Modifications to the `PENBBScan2D` functions such that it retakes measurement right on the spot 
 instead of saving them to a `JSON` file to retake them at the end

```diff
- Be careful that no other application on the PC is based on java processes!!
```


Let me know if you require other modifications or have some questions/comments.